### PR TITLE
Fix unable to resume downloads if >1000 in list

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -117,7 +117,7 @@ function resumeDownload(DownloadItems) {
  * downloadManager :              search for downloads and call resumeDownload
  * @param {Object} query          Download item search criteria
  */
-function downloadManager(query = {}) {
+function downloadManager(query = { orderBy: ['-startTime'] }) {
     chrome.downloads.search(query, resumeDownload);
 }
 


### PR DESCRIPTION
I noticed that the extension didn't work for me. After some testing I figured out that the reason is that `chrome.downloads.search()` returns at max 1000 items *in random order*.

This means if the user has more than 1000 downloads in the list, the extension won't load the newest ones and is thus unable to resume (which can easily happen if you don't clear the downloads page for multiple years).

A manual workaround is to simply clear the downloads page with the button in the top right.

This PR should fix this by always loading the newest downloads from the list.